### PR TITLE
Remove nose dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ Requirements
 
 * Django 1.2+
 * MongoEngine
-* nose - https://github.com/nose-devs/nose
 
 Usage
 =====

--- a/mongotesting/testcases.py
+++ b/mongotesting/testcases.py
@@ -1,5 +1,4 @@
 #coding: utf-8
-from nose.plugins.skip import SkipTest
 
 from mongoengine.python_support import PY3
 from mongoengine import connect
@@ -23,9 +22,6 @@ class MongoTestCase(TestCase):
     """
     
     def _pre_setup(self):
-        if PY3:
-            raise SkipTest('django does not have Python 3 support')
-
         from mongoengine.connection import connect, disconnect, get_connection
         for db_name, db_alias in settings.MONGO_DATABASES.items():
             connection = get_connection(db_alias)

--- a/mongotesting/testrunners.py
+++ b/mongotesting/testrunners.py
@@ -1,6 +1,5 @@
 #coding: utf-8
 from django.test.simple import DjangoTestSuiteRunner
-from nose.plugins.skip import SkipTest
 from mongoengine.python_support import PY3
 from mongoengine import connect
 try:

--- a/setup.py
+++ b/setup.py
@@ -13,5 +13,5 @@ setup(
     packages=[
         'mongotesting',
     ],
-    install_requires=['django', 'mongoengine', 'nose'],
+    install_requires=['django', 'mongoengine'],
 )


### PR DESCRIPTION
The `nose` dependency isn't necessary, so this PR removes it.

/cc @qMax https://github.com/snormore/django-mongotesting/issues/1
